### PR TITLE
Update BootstrapXL.css

### DIFF
--- a/BootstrapXL.css
+++ b/BootstrapXL.css
@@ -267,4 +267,14 @@
     .hidden-xl {
         display: none !important;
     }
+    
+
+    .visible-lg-block,
+    .visible-lg-inline,
+    .visible-lg-inline-block,
+    .visible-lg{
+        display: none !important;
+    }
+
+    
 }


### PR DESCRIPTION
Ooooooooooooo my first ever pull!

In xl lg elements were still visible. This cures it. 

BTW a MILLION thanks for this. Layout on 1360 displays using lg was horrible

ATB
Steve
